### PR TITLE
add actions_events table

### DIFF
--- a/models/core/actions_events.sql
+++ b/models/core/actions_events.sql
@@ -1,0 +1,53 @@
+{{
+  config(
+    materialized='incremental',
+    cluster_by='block_timestamp',
+    unique_key='action_id',
+    tags=['actions']
+  )
+}}
+
+with
+txs as (
+
+  select * from {{ ref('stg_txs') }}
+  where {{ incremental_load_filter('block_timestamp') }}
+
+),
+
+actions as (
+
+  select
+
+    tx_id,
+    block_timestamp,
+    index as action_index,
+    case
+      when value like '%CreateAccount%' then value
+      else OBJECT_KEYS(value)[0]::string
+    end as action_name,
+    case
+      when action_name = 'CreateAccount' then '{}'
+      else value[action_name]
+    end as action_data
+
+  from txs, lateral flatten( input => tx:actions )
+
+),
+
+final as (
+
+  select
+
+    concat_ws('-', tx_id, action_index) as action_id,
+    tx_id as tx_hash,
+    block_timestamp,
+    action_index,
+    action_name,
+    try_parse_json(action_data) as action_data
+
+  from actions
+
+)
+
+select * from final

--- a/models/core/actions_events.yml
+++ b/models/core/actions_events.yml
@@ -1,0 +1,38 @@
+version: 2
+
+models:
+  - name: actions_events
+    description: |-
+      This table extracts all action events from a transaction and stores the argument data under action_data.
+
+    columns:
+      - name: action_id
+        description: The `action_id` as compiled from `tx_id` and `action_index`. This is unique for each record.
+        tests:
+          - unique
+          - not_null
+
+      - name: tx_hash
+        description: The hash of the transaction, this is the primary key for this table.
+        tests:
+          - not_null
+
+      - name: block_timestamp
+        description: The `block_timestamp` taken from block headers.  The time when the block was created.
+        tests:
+          - not_null
+
+      - name: action_index
+        description: The index of the current `action_name` and `action_data` in the order in which it appeared in the transaction.
+        tests:
+          - not_null
+
+      - name: action_name
+        description: The name of the action performed.
+        tests:
+          - not_null
+
+      - name: action_data
+        description: A JSON object containing the argument data that was called by the `action_event`, if any.
+        tests:
+          - not_null


### PR DESCRIPTION
Add actions table as described in the actions table issue, closing #5 .

```
23:28:31 | Concurrency: 4 threads (target='dev')
23:28:31 |
23:28:31 | 1 of 1 START incremental model DEV.actions_events.................... [RUN]
23:28:36 | 1 of 1 OK created incremental model DEV.actions_events............... [SUCCESS 1 in 5.34s]
23:28:36 |
23:28:36 | Finished running 1 incremental model in 10.56s.
```