### PR TITLE
[hotfix]fixes for `txs` and `stg_blocks`

### DIFF
--- a/models/core/txs.sql
+++ b/models/core/txs.sql
@@ -9,17 +9,13 @@
 -- WIP -- below serves as example
 
 with base_txs as (
-    select * from {{ deduped_txs("near_txs") }}
+    select * from {{ ref("stg_txs") }}
+    where {{ incremental_load_filter("block_timestamp") }}
 ),
 final as (  
     select
-        block_timestamp,
-        tx:nonce::string as nonce,
-        tx_id as tx_hash,
-        -- Build out more columns here from `txs`
-        -- ...    
+        *    
     from base_txs
-where {{ incremental_load_filter("block_timestamp") }}
 )
 
 select * from final

--- a/models/staging/stg_blocks.sql
+++ b/models/staging/stg_blocks.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized='incremental',
-        unique_key='tx_id',
+        unique_key='block_id',
         incremental_strategy = 'delete+insert',
         tags=['core'],
         cluster_by=['block_timestamp']


### PR DESCRIPTION
So it seems like the prod never get to run because of the following errors
<img width="845" alt="image" src="https://user-images.githubusercontent.com/30974572/155839012-2ed51332-ab4c-4220-853a-a04f98e112f7.png">

Test:
```
make dbt-console                                                                         chuxinhuang@Chuxins-MacBook-Pro
docker-compose run dbt_console
Creating near_dbt_dbt_console_run ... done
root@11b8255e42ea:/near# cd models
root@11b8255e42ea:/near/models# dbt run -s stg_blocks
Running with dbt=0.21.1
Found 6 models, 53 tests, 0 snapshots, 0 analyses, 175 macros, 0 operations, 0 seed files, 2 sources, 0 exposures

10:02:09 | Concurrency: 4 threads (target='dev')
10:02:09 | 
10:02:09 | 1 of 1 START incremental model DEV.stg_blocks........................ [RUN]
10:02:20 | 1 of 1 OK created incremental model DEV.stg_blocks................... [SUCCESS 1 in 10.48s]
10:02:20 | 
10:02:20 | Finished running 1 incremental model in 18.33s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

```
dbt run -s core.txs
Running with dbt=0.21.1
Found 6 models, 53 tests, 0 snapshots, 0 analyses, 175 macros, 0 operations, 0 seed files, 2 sources, 0 exposures

10:02:50 | Concurrency: 4 threads (target='dev')
10:02:50 | 
10:02:50 | 1 of 1 START incremental model DEV.txs............................... [RUN]
10:03:03 | 1 of 1 OK created incremental model DEV.txs.......................... [SUCCESS 1 in 13.18s]
10:03:03 | 
10:03:03 | Finished running 1 incremental model in 20.20s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```