### PR TITLE
Create table `actions_events_addkey`

### DIFF
--- a/models/core/actions_events_addkey.sql
+++ b/models/core/actions_events_addkey.sql
@@ -1,0 +1,35 @@
+{{
+  config(
+    materialized='table',
+    unique_key='action_id'
+  )
+}}
+
+with
+action_events as (
+
+  select * from {{ ref('actions_events') }}
+  where action_name = 'AddKey'
+
+),
+
+addkey_events as (
+
+  select
+
+    action_id,
+    tx_hash,
+    block_timestamp,
+    action_data, -- temp. to be deleted prior to merge
+    action_data:access_key:nonce::float as nonce,
+    action_data:public_key::string as public_key,
+    action_data:access_key:permission as permission,
+    action_data:access_key:permission:FunctionCall:allowance::float as allowance,
+    action_data:access_key:permission:FunctionCall:method_names as method_name,
+    action_data:access_key:permission:FunctionCall:receiver_id::string as receiver_id
+
+  from action_events
+
+)
+
+select * from addkey_events

--- a/models/core/actions_events_addkey.sql
+++ b/models/core/actions_events_addkey.sql
@@ -18,9 +18,8 @@ addkey_events as (
   select
 
     action_id,
-    tx_hash,
+    txn_hash,
     block_timestamp,
-    action_data, -- temp. to be deleted prior to merge
     action_data:access_key:nonce::float as nonce,
     action_data:public_key::string as public_key,
     action_data:access_key:permission as permission,

--- a/models/core/actions_events_addkey.sql
+++ b/models/core/actions_events_addkey.sql
@@ -21,7 +21,7 @@ addkey_events as (
   select
 
     action_id,
-    tx_hash as txn_hash,
+    txn_hash,
     block_timestamp,
     action_data:access_key:nonce::float as nonce,
     action_data:public_key::string as public_key,

--- a/models/core/actions_events_addkey.sql
+++ b/models/core/actions_events_addkey.sql
@@ -23,10 +23,10 @@ addkey_events as (
     action_id,
     txn_hash,
     block_timestamp,
-    action_data:access_key:nonce::float as nonce,
+    action_data:access_key:nonce::number as nonce,
     action_data:public_key::string as public_key,
-    action_data:access_key:permission::object as permission,
-    action_data:access_key:permission:FunctionCall:allowance::float as allowance,
+    action_data:access_key:permission as permission,
+    action_data:access_key:permission:FunctionCall:allowance::number as allowance,
     action_data:access_key:permission:FunctionCall:method_names::array as method_name,
     action_data:access_key:permission:FunctionCall:receiver_id::string as receiver_id
 

--- a/models/core/actions_events_addkey.yml
+++ b/models/core/actions_events_addkey.yml
@@ -12,7 +12,7 @@ models:
           - unique
           - not_null
 
-      - name: tx_hash
+      - name: txn_hash
         description: The hash of the transaction, this is the primary key for this table.
         tests:
           - not_null

--- a/models/core/actions_events_addkey.yml
+++ b/models/core/actions_events_addkey.yml
@@ -1,0 +1,38 @@
+version: 2
+
+models:
+  - name: actions_events
+    description: |-
+      This table extracts all action events from a transaction and stores the argument data under action_data.
+
+    columns:
+      - name: action_id
+        description: The `action_id` as compiled from `tx_id` and `action_index`. This is unique for each record.
+        tests:
+          - unique
+          - not_null
+
+      - name: tx_hash
+        description: The hash of the transaction, this is the primary key for this table.
+        tests:
+          - not_null
+
+      - name: block_timestamp
+        description: The `block_timestamp` taken from block headers.  The time when the block was created.
+        tests:
+          - not_null
+
+      - name: nonce
+        description: Nonce for transactions.
+        tests:
+          - not_null
+
+      - name: public_key
+        description: The public key of an AccessKey which was used to sign the original transaction. In case of a deposit refund, the public key is empty (all bytes are 0).
+        tests:
+          - not_null
+
+      - name: permission
+        description: Permissions granted to the contract by the signer.
+        tests:
+          - not_null

--- a/models/core/actions_events_addkey.yml
+++ b/models/core/actions_events_addkey.yml
@@ -13,7 +13,7 @@ models:
           - not_null
 
       - name: txn_hash
-        description: The hash of the transaction, this is the primary key for this table.
+        description: The hash of the transaction..
         tests:
           - not_null
 

--- a/models/core/actions_events_addkey.yml
+++ b/models/core/actions_events_addkey.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: actions_events_addkey
     description: |-
-      This table extracts all AkkDey events from actions and stores the argument data under action_data.
+      This table extracts all AddKey events from actions and stores the argument data under action_data.
 
     columns:
       - name: action_id

--- a/models/core/actions_events_addkey.yml
+++ b/models/core/actions_events_addkey.yml
@@ -1,7 +1,7 @@
 version: 2
 
 models:
-  - name: actions_events
+  - name: actions_events_addkey
     description: |-
       This table extracts all action events from a transaction and stores the argument data under action_data.
 
@@ -36,3 +36,15 @@ models:
         description: Permissions granted to the contract by the signer.
         tests:
           - not_null
+
+      - name: allowance
+        description: Amount of NEAR approved for use in unadjusted format (10^24). NULL if permission is FullAccess.
+        tests:
+
+      - name: method_name
+        description: Name of the method(s) approved for use. NULL if permission is FullAccess.
+        tests:
+
+      - name: receiver_id
+        description: the account ID of the destination of this transaction. NULL if permission is FullAccess.
+        tests:

--- a/models/core/actions_events_addkey.yml
+++ b/models/core/actions_events_addkey.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: actions_events_addkey
     description: |-
-      This table extracts all action events from a transaction and stores the argument data under action_data.
+      This table extracts all AkkDey events from actions and stores the argument data under action_data.
 
     columns:
       - name: action_id
@@ -29,8 +29,6 @@ models:
 
       - name: public_key
         description: The public key of an AccessKey which was used to sign the original transaction. In case of a deposit refund, the public key is empty (all bytes are 0).
-        tests:
-          - not_null
 
       - name: permission
         description: Permissions granted to the contract by the signer.
@@ -39,12 +37,9 @@ models:
 
       - name: allowance
         description: Amount of NEAR approved for use in unadjusted format (10^24). NULL if permission is FullAccess.
-        tests:
 
       - name: method_name
         description: Name of the method(s) approved for use. NULL if permission is FullAccess.
-        tests:
 
       - name: receiver_id
         description: the account ID of the destination of this transaction. NULL if permission is FullAccess.
-        tests:


### PR DESCRIPTION
This PR closes issue #20 by parsing the `actions_events` table for instances of `AddKey`.
  
  
Note: the updated commit assumes the upstream `actions_events` table has been updated to `txn_hash`. As such, this should be merged after that PR.