### PR TITLE
add receipts

### DIFF
--- a/models/core/receipts.sql
+++ b/models/core/receipts.sql
@@ -1,0 +1,29 @@
+{{
+    config(
+        materialized='incremental',
+        unique_key= 'txn_hash',
+        incremental_strategy = 'delete+insert',
+        tags=['core', 'transactions'],
+        cluster_by = ['block_timestamp']
+    )
+}}
+
+select
+
+    block_timestamp,
+    block_hash,
+    txn_hash,
+    tx_receipt[0]:id::string as receipt_object_id,
+
+    case when tx_receipt[0]:outcome:receipt_ids[1] is not NULL
+         then tx_receipt[0]:outcome:receipt_ids
+         else tx_receipt[0]:outcome:receipt_ids[0]::string
+    end as receipt_outcome_id,
+
+    tx_receipt[0]:outcome:status as status_value,
+    tx_receipt[0]:outcome:logs as logs,
+    tx_receipt[0]:proof as proof,
+    tx_receipt[0]:outcome:metadata as metadata
+
+from {{ ref('transactions') }}
+order by block_timestamp desc

--- a/models/core/receipts.yml
+++ b/models/core/receipts.yml
@@ -1,0 +1,56 @@
+
+version: 2
+
+models:
+  - name: receipts
+    description: "Near receipts."
+
+    columns:
+
+      - name: block_timestamp
+        description: The time the block was minted.
+        tests:
+          - not_null
+
+      - name: block_hash
+        description: Unique identifier (hash) of this block.
+        tests:
+          - not_null
+
+      - name: txn_hash
+        description: Unique identifier (hash) of this transaction.
+        tests:
+          - not_null
+          - unique
+
+      - name: receipt_object_id
+        description: Unique identifier of the receipt object for this transaction.
+        tests:
+          - not_null
+          - unique
+
+      - name: receipt_outcome_id
+        description: Unique identifier(s) of the receipt outcome for this transaction.
+        tests:
+          - not_null
+          - unique
+
+      - name: status_value
+        description: Status information (array) for this transaction.
+        tests:
+          - not_null
+
+      - name: logs
+        description: Logs (array) for this transaction.
+        tests:
+          - not_null
+
+      - name: proof
+        description: Proof (array) for this transaction.
+        tests:
+          - not_null
+
+      - name: metadata
+        description: Metadata (array) for this transaction.
+        tests:
+          - not_null


### PR DESCRIPTION
# Description

Add receipts table to core tables. The receipts table parses some of the information in the `tx_receipts` column of the `transactions` table. 

Schema can still be adjusted since didn't get 100% green lights from peeps. 
A preview is available in snowflake in dev environment to check out the data in full to recommend any changes.

# Tests 

- [ ] Please provide evidence of your successful `dbt run` / `dbt test` here 
![image](https://user-images.githubusercontent.com/101434717/167283927-b62a9db2-1412-45cb-95a5-c7c482d3ce59.png)

- [ ] Any comparison between `prod` and `dev` for any schema change


# Checklist
- [ ] Follow [dbt style guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md)
- [ ] Tag the person(s) responsible for reviewing proposed changes @chuxinh @forgxyz 
- [ ] Notes to deployment, if a `full-refresh` is needed for any table
