### PR TITLE
[Hotfix] Update allowance column type to float

### DIFF
--- a/models/core/actions_events_addkey.sql
+++ b/models/core/actions_events_addkey.sql
@@ -26,7 +26,7 @@ addkey_events as (
     action_data:access_key:nonce::number as nonce,
     action_data:public_key::string as public_key,
     action_data:access_key:permission as permission,
-    action_data:access_key:permission:FunctionCall:allowance::number as allowance,
+    action_data:access_key:permission:FunctionCall:allowance::float as allowance,
     action_data:access_key:permission:FunctionCall:method_names::array as method_name,
     action_data:access_key:permission:FunctionCall:receiver_id::string as receiver_id,
     ingested_at


### PR DESCRIPTION
# Description
NEAR incremental has been failing for the past few days due to `allowance` column in `add_key` action with more than 38 digits.
![image](https://user-images.githubusercontent.com/30974572/168837743-317ccaf6-c82f-4923-bf59-fe30715089d5.png)


# Tests 

- [x] Please provide evidence of your successful `dbt run` / `dbt test` here
<img width="710" alt="image" src="https://user-images.githubusercontent.com/30974572/168838049-326bad3e-d579-4836-87ed-46973ab56803.png">
- [x] Any comparison between `prod` and `dev` for any schema change

dev:
<img width="133" alt="image" src="https://user-images.githubusercontent.com/30974572/168839075-2532fc3e-9e69-48c1-b7f0-cc75d3994e41.png">

prod:
<img width="138" alt="image" src="https://user-images.githubusercontent.com/30974572/168839183-34115eb5-2f66-4acf-8e72-7dd9faf532f0.png">



# Checklist
- [x] Follow [dbt style guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md)
- [x] Tag the person(s) responsible for reviewing proposed changes
- [x] Notes to deployment, if a `full-refresh` is needed for any table: `full-refresh` for this table
