### PR TITLE
remove secure view config from bronze

### DIFF
--- a/models/bronze/bronze__blocks.sql
+++ b/models/bronze/bronze__blocks.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = 'view',
-    secure = true
+    materialized = 'view'
 ) }}
 
 SELECT

--- a/models/bronze/bronze__transactions.sql
+++ b/models/bronze/bronze__transactions.sql
@@ -1,6 +1,5 @@
 {{ config (
-    materialized = 'view',
-    secure = true
+    materialized = 'view'
 ) }}
 
 SELECT


### PR DESCRIPTION
# Description

_Please include a summary of changes and related issue (if any)._
Removes the config `secure = true` from bronze views. This was added as only secure views can be shared between Snowflake accounts. As the bronze views are excluded from the share, we no longer need this config.

# Tests

- [ ] Please provide evidence of your successful `dbt run` / `dbt test` here
- [ ] Any comparison between `prod` and `dev` for any schema change


# Checklist
- [ ] Follow [dbt style guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md)
- [ ] Tag the person(s) responsible for reviewing proposed changes
- [ ] Notes to deployment, if a `full-refresh` is needed for any table
- [ ] Run `git merge main` to pull any changes from remote into your branch prior to merge.
