### PR TITLE
Tx attached gas bugfix

### DIFF
--- a/models/silver/silver__transactions.sql
+++ b/models/silver/silver__transactions.sql
@@ -89,7 +89,10 @@ FINAL AS (
     t.transaction_tokens_burnt + r.receipt_tokens_burnt AS transaction_fee,
     t._ingested_at,
     t._inserted_timestamp,
-    actions.attached_gas as attached_gas
+    COALESCE(
+        actions.attached_gas,
+        gas_used
+    ) AS attached_gas
   FROM
     transactions AS t
     JOIN receipts AS r

--- a/models/silver/silver__transactions.sql
+++ b/models/silver/silver__transactions.sql
@@ -29,6 +29,16 @@ WITH base_transactions AS (
         _inserted_timestamp DESC
     ) = 1
 ),
+
+actions as (
+    select 
+        tx_hash,
+        sum(value:FunctionCall:gas) as attached_gas
+    from base_transactions,
+    lateral flatten(input => tx:actions)
+    group by 1
+),
+
 transactions AS (
   SELECT
     block_id AS block_id,
@@ -42,10 +52,6 @@ transactions AS (
     tx,
     tx :outcome :outcome :gas_burnt :: NUMBER AS transaction_gas_burnt,
     tx :outcome :outcome :tokens_burnt :: NUMBER AS transaction_tokens_burnt,
-    GET(
-      tx :actions,
-      0
-    ) :FunctionCall :gas :: NUMBER AS attached_gas,
     _ingested_at,
     _inserted_timestamp
   FROM
@@ -81,16 +87,14 @@ FINAL AS (
     t.tx,
     t.transaction_gas_burnt + r.receipt_gas_burnt AS gas_used,
     t.transaction_tokens_burnt + r.receipt_tokens_burnt AS transaction_fee,
-    COALESCE(
-      t.attached_gas,
-      gas_used
-    ) AS attached_gas,
     t._ingested_at,
-    t._inserted_timestamp
+    t._inserted_timestamp,
+    actions.attached_gas as attached_gas
   FROM
     transactions AS t
     JOIN receipts AS r
     ON t.tx_hash = r.tx_hash
+    join actions on t.tx_hash = actions.tx_hash
 )
 SELECT
   *


### PR DESCRIPTION
# Description

Fixes #74.

Currently, the transactions table takes the gas of only the first action of the transaction. Some transactions can have multiple actions.

This PR sums the attached gas of all the actions together. This brings us to match the values given out by the explorer.


# Tests

![image](https://user-images.githubusercontent.com/51023861/181523687-183df3a4-7d26-43dc-b3c2-75ab4e59169d.png)

This is for incremental run though.

# Notes

A `--full-refresh` is required to update bugged values.
