### PR TITLE
Added tx_status to transactions table

### DIFF
--- a/models/core/core__fact_transactions.sql
+++ b/models/core/core__fact_transactions.sql
@@ -22,6 +22,7 @@ SELECT
     tx,
     gas_used,
     transaction_fee,
-    attached_gas
+    attached_gas,
+    tx_status
 FROM
     transactions

--- a/models/core/core__fact_transactions.yml
+++ b/models/core/core__fact_transactions.yml
@@ -122,3 +122,12 @@ models:
               column_type_list:
                 - NUMBER
                 - FLOAT
+
+      - name: TX_STATUS
+        description: "{{ doc('tx_status')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR

--- a/models/descriptions/tx_status.md
+++ b/models/descriptions/tx_status.md
@@ -1,0 +1,5 @@
+{% docs tx_status %}
+
+Indicates whether the transaction failed or succeeded.
+
+{% enddocs %}

--- a/models/silver/silver__transactions.yml
+++ b/models/silver/silver__transactions.yml
@@ -138,3 +138,12 @@ models:
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_NTZ
+
+      - name: TX_STATUS
+        description: "{{ doc('tx_status')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR


### PR DESCRIPTION
# Description

_Please include a summary of changes and related issue (if any)._
Added `tx_status` as a new column to the `transactions` table so it would be easier to check if the transaction has succeeded or failed. Solves issue #87.


# Tests

- [x] Please provide evidence of your successful `dbt run` / `dbt test` here

**SILVER_TRANSACTIONS**

`dbt run`

```
root@f82ab8553319:/near/models/silver# dbt run -s silver__transactions+ --full-refresh
18:23:59  Running with dbt=1.0.0
18:24:08  Found 38 models, 605 tests, 0 snapshots, 0 analyses, 628 macros, 1 operation, 1 seed file, 2 sources, 0 exposures, 0 metrics
18:24:08  
18:24:22  
18:24:22  Running 1 on-run-start hook
18:24:22  1 of 1 START hook: near.on-run-start.0.......................................... [RUN]
18:24:22  1 of 1 OK hook: near.on-run-start.0............................................. [OK in 0.00s]
18:24:22  
18:24:22  Concurrency: 4 threads (target='dev')
18:24:22
18:24:22  1 of 31 START incremental model silver.transactions............................. [RUN]
22:47:17  1 of 31 OK created incremental model silver.transactions........................ [SUCCESS 1 in 15774.96s]
22:47:17  2 of 31 START view model core.fact_transactions................................. [RUN]
22:47:17  3 of 31 START view model legacy.transactions.................................... [RUN]
22:47:17  4 of 31 START incremental model metrics.active_wallets.......................... [RUN]
22:47:17  5 of 31 START incremental model metrics.daily_gas............................... [RUN]
22:47:23  2 of 31 OK created view model core.fact_transactions............................ [SUCCESS 1 in 5.74s]
22:47:23  6 of 31 START incremental model metrics.daily_transactions...................... [RUN]
22:47:23  3 of 31 OK created view model legacy.transactions............................... [SUCCESS 1 in 6.20s]
22:47:23  7 of 31 START incremental model silver.actions_events........................... [RUN]
22:47:44  5 of 31 OK created incremental model metrics.daily_gas.......................... [SUCCESS 1 in 26.83s]
22:47:44  8 of 31 START incremental model silver.prices_oracle............................ [RUN]
22:47:46  4 of 31 OK created incremental model metrics.active_wallets..................... [SUCCESS 1 in 28.90s]
22:47:46  9 of 31 START incremental model silver.receipts................................. [RUN]
22:48:12  6 of 31 OK created incremental model metrics.daily_transactions................. [SUCCESS 1 in 49.48s]
22:48:12  10 of 31 START view model core.metrics_daily_gas................................ [RUN]
22:48:16  10 of 31 OK created view model core.metrics_daily_gas........................... [SUCCESS 1 in 3.35s]
22:48:16  11 of 31 START view model legacy.metrics_daily_gas.............................. [RUN]
22:48:19  11 of 31 OK created view model legacy.metrics_daily_gas......................... [SUCCESS 1 in 3.10s]
22:48:19  12 of 31 START view model core.metrics_active_wallets........................... [RUN]
22:48:22  12 of 31 OK created view model core.metrics_active_wallets...................... [SUCCESS 1 in 3.66s]
22:48:22  13 of 31 START view model legacy.metrics_active_wallets......................... [RUN]
22:48:26  13 of 31 OK created view model legacy.metrics_active_wallets.................... [SUCCESS 1 in 3.55s]
22:48:26  14 of 31 START view model core.metrics_daily_transactions....................... [RUN]
22:48:30  14 of 31 OK created view model core.metrics_daily_transactions.................. [SUCCESS 1 in 3.94s]
22:48:30  15 of 31 START view model legacy.metrics_daily_transactions..................... [RUN]
22:48:33  15 of 31 OK created view model legacy.metrics_daily_transactions................ [SUCCESS 1 in 3.25s]
22:50:01  8 of 31 OK created incremental model silver.prices_oracle....................... [SUCCESS 1 in 137.10s]
22:50:01  16 of 31 START view model core.fact_prices...................................... [RUN]
22:50:06  16 of 31 OK created view model core.fact_prices................................. [SUCCESS 1 in 4.61s]
23:23:57  7 of 31 OK created incremental model silver.actions_events...................... [SUCCESS 1 in 2193.48s]
23:23:57  17 of 31 START view model core.fact_actions_events.............................. [RUN]
23:23:57  18 of 31 START view model legacy.actions_events................................. [RUN]
23:23:57  19 of 31 START incremental model silver.actions_events_addkey................... [RUN]
23:24:00  18 of 31 OK created view model legacy.actions_events............................ [SUCCESS 1 in 3.77s]
23:24:00  20 of 31 START incremental model silver.actions_events_function_call............ [RUN]
23:24:01  17 of 31 OK created view model core.fact_actions_events......................... [SUCCESS 1 in 4.13s]
23:24:01  21 of 31 START incremental model silver.transfers............................... [RUN]
23:24:29  19 of 31 OK created incremental model silver.actions_events_addkey.............. [SUCCESS 1 in 31.84s]
23:24:29  22 of 31 START view model core.fact_actions_events_addkey....................... [RUN]
23:24:32  22 of 31 OK created view model core.fact_actions_events_addkey.................. [SUCCESS 1 in 2.95s]
23:24:32  23 of 31 START view model legacy.actions_events_addkey.......................... [RUN]
23:24:34  23 of 31 OK created view model legacy.actions_events_addkey..................... [SUCCESS 1 in 2.91s]
23:39:22  9 of 31 OK created incremental model silver.receipts............................ [SUCCESS 1 in 3096.50s]
23:39:22  24 of 31 START view model core.fact_receipts.................................... [RUN]
23:39:22  25 of 31 START view model legacy.receipts....................................... [RUN]
23:39:27  24 of 31 OK created view model core.fact_receipts............................... [SUCCESS 1 in 4.73s]
23:39:27  25 of 31 OK created view model legacy.receipts.................................. [SUCCESS 1 in 4.91s]
23:40:43  21 of 31 OK created incremental model silver.transfers.......................... [SUCCESS 1 in 1001.79s]
23:40:43  26 of 31 START view model core.fact_transfers................................... [RUN]
23:40:43  27 of 31 START view model legacy.transfers...................................... [RUN]
23:40:47  27 of 31 OK created view model legacy.transfers................................. [SUCCESS 1 in 4.41s]
23:40:47  26 of 31 OK created view model core.fact_transfers.............................. [SUCCESS 1 in 4.61s]
23:49:27  20 of 31 OK created incremental model silver.actions_events_function_call....... [SUCCESS 1 in 1523.44s]
23:49:27  28 of 31 START view model core.fact_actions_events_function_call................ [RUN]
23:49:27  29 of 31 START view model legacy.actions_events_function_call................... [RUN]
23:49:27  30 of 31 START incremental model silver.dex_swaps............................... [RUN]
23:49:31  28 of 31 OK created view model core.fact_actions_events_function_call........... [SUCCESS 1 in 4.72s]
23:49:32  29 of 31 OK created view model legacy.actions_events_function_call.............. [SUCCESS 1 in 4.87s]
23:50:36  30 of 31 OK created incremental model silver.dex_swaps.......................... [SUCCESS 1 in 69.41s]
23:50:36  31 of 31 START view model core.ez_dex_swaps..................................... [RUN]
23:50:39  31 of 31 OK created view model core.ez_dex_swaps................................ [SUCCESS 1 in 3.19s]
23:50:39  
23:50:39  Finished running 11 incremental models, 20 view models, 1 hook in 19591.41s.
23:50:39  
23:50:39  Completed successfully
23:50:39
23:50:39  Done. PASS=31 WARN=0 ERROR=0 SKIP=0 TOTAL=31
```

`dbt_test`

```
root@f82ab8553319:/near/models/silver# dbt test --select silver__transactions
00:30:36  Running with dbt=1.0.0
00:30:42  Found 38 models, 605 tests, 0 snapshots, 0 analyses, 628 macros, 1 operation, 1 seed file, 2 sources, 0 exposures, 0 metrics
00:30:42  
00:30:49  
00:30:49  Running 1 on-run-start hook
00:30:49  1 of 1 START hook: near.on-run-start.0.......................................... [RUN]
00:30:49  1 of 1 OK hook: near.on-run-start.0............................................. [OK in 0.00s]
00:30:49
00:30:49  Concurrency: 4 threads (target='dev')
00:30:49
00:30:49  1 of 34 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_ATTACHED_GAS__NUMBER__FLOAT [RUN]
00:30:49  2 of 34 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_BLOCK_HASH__STRING__VARCHAR [RUN]
00:30:49  3 of 34 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_BLOCK_ID__NUMBER__FLOAT [RUN]
00:30:49  4 of 34 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_BLOCK_TIMESTAMP__TIMESTAMP_NTZ [RUN]
00:30:54  3 of 34 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_BLOCK_ID__NUMBER__FLOAT [PASS in 4.96s]
00:30:54  5 of 34 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_GAS_USED__NUMBER__FLOAT [RUN]
00:30:54  1 of 34 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_ATTACHED_GAS__NUMBER__FLOAT [PASS in 5.11s]
00:30:54  6 of 34 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_NONCE__NUMBER [RUN]
00:30:54  2 of 34 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_BLOCK_HASH__STRING__VARCHAR [PASS in 5.19s]
00:30:54  4 of 34 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_BLOCK_TIMESTAMP__TIMESTAMP_NTZ [PASS in 5.19s]
00:30:54  7 of 34 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_SIGNATURE__STRING__VARCHAR [RUN]
00:30:54  8 of 34 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_TRANSACTION_FEE__NUMBER__FLOAT [RUN]
00:30:59  5 of 34 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_GAS_USED__NUMBER__FLOAT [PASS in 4.78s]
00:30:59  9 of 34 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_TX_HASH__STRING__VARCHAR [RUN]
00:30:59  7 of 34 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_SIGNATURE__STRING__VARCHAR [PASS in 4.60s]
00:30:59  10 of 34 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_TX_RECEIVER__STRING__VARCHAR [RUN]
00:30:59  6 of 34 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_NONCE__NUMBER [PASS in 4.94s]
00:30:59  11 of 34 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_TX_SIGNER__STRING__VARCHAR [RUN]
00:30:59  8 of 34 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_TRANSACTION_FEE__NUMBER__FLOAT [PASS in 4.87s]
00:30:59  12 of 34 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_TX_STATUS__STRING__VARCHAR [RUN]
00:31:04  10 of 34 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_TX_RECEIVER__STRING__VARCHAR [PASS in 4.65s]
00:31:04  13 of 34 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_TX__OBJECT__VARIANT [RUN]
00:31:04  12 of 34 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_TX_STATUS__STRING__VARCHAR [PASS in 4.50s]
00:31:04  14 of 34 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions__INGESTED_AT__TIMESTAMP_NTZ [RUN]
00:31:04  9 of 34 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_TX_HASH__STRING__VARCHAR [PASS in 5.05s]
00:31:04  11 of 34 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_TX_SIGNER__STRING__VARCHAR [PASS in 4.74s]
00:31:04  15 of 34 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions__INSERTED_TIMESTAMP__TIMESTAMP_NTZ [RUN]
00:31:04  16 of 34 START test dbt_expectations_expect_row_values_to_have_recent_data_silver__transactions_BLOCK_TIMESTAMP__day__1 [RUN]
00:31:07  14 of 34 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions__INGESTED_AT__TIMESTAMP_NTZ [PASS in 3.10s]
00:31:07  17 of 34 START test dbt_utils_unique_combination_of_columns_silver__transactions_tx_hash [RUN]
00:31:07  13 of 34 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions_TX__OBJECT__VARIANT [PASS in 3.49s]
00:31:07  18 of 34 START test not_null_silver__transactions_ATTACHED_GAS.................. [RUN]
00:31:08  15 of 34 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__transactions__INSERTED_TIMESTAMP__TIMESTAMP_NTZ [PASS in 4.28s]
00:31:08  19 of 34 START test not_null_silver__transactions_BLOCK_HASH.................... [RUN]
00:31:10  18 of 34 PASS not_null_silver__transactions_ATTACHED_GAS........................ [PASS in 3.33s]
00:31:10  20 of 34 START test not_null_silver__transactions_BLOCK_ID...................... [RUN]
00:31:12  19 of 34 PASS not_null_silver__transactions_BLOCK_HASH.......................... [PASS in 3.71s]
00:31:12  21 of 34 START test not_null_silver__transactions_BLOCK_TIMESTAMP............... [RUN]
00:31:13  20 of 34 PASS not_null_silver__transactions_BLOCK_ID............................ [PASS in 2.93s]
00:31:13  22 of 34 START test not_null_silver__transactions_GAS_USED...................... [RUN]
00:31:15  21 of 34 PASS not_null_silver__transactions_BLOCK_TIMESTAMP..................... [PASS in 2.70s]
00:31:15  23 of 34 START test not_null_silver__transactions_NONCE......................... [RUN]
00:31:16  22 of 34 PASS not_null_silver__transactions_GAS_USED............................ [PASS in 2.82s]
00:31:16  24 of 34 START test not_null_silver__transactions_SIGNATURE..................... [RUN]
00:31:18  23 of 34 PASS not_null_silver__transactions_NONCE............................... [PASS in 2.97s]
00:31:18  25 of 34 START test not_null_silver__transactions_TRANSACTION_FEE............... [RUN]
00:31:19  24 of 34 PASS not_null_silver__transactions_SIGNATURE........................... [PASS in 2.67s]
00:31:19  26 of 34 START test not_null_silver__transactions_TX............................ [RUN]
00:31:21  25 of 34 PASS not_null_silver__transactions_TRANSACTION_FEE..................... [PASS in 3.07s]
00:31:21  27 of 34 START test not_null_silver__transactions_TX_HASH....................... [RUN]
00:31:24  27 of 34 PASS not_null_silver__transactions_TX_HASH............................. [PASS in 3.70s]
00:31:24  28 of 34 START test not_null_silver__transactions_TX_RECEIVER................... [RUN]
00:31:27  28 of 34 PASS not_null_silver__transactions_TX_RECEIVER......................... [PASS in 2.94s]
00:31:27  29 of 34 START test not_null_silver__transactions_TX_SIGNER..................... [RUN]
00:31:29  16 of 34 PASS dbt_expectations_expect_row_values_to_have_recent_data_silver__transactions_BLOCK_TIMESTAMP__day__1 [PASS in 25.24s]
00:31:29  30 of 34 START test not_null_silver__transactions_TX_STATUS..................... [RUN]
00:31:31  29 of 34 PASS not_null_silver__transactions_TX_SIGNER........................... [PASS in 3.48s]
00:31:31  31 of 34 START test not_null_silver__transactions__INGESTED_AT.................. [RUN]
00:31:32  30 of 34 PASS not_null_silver__transactions_TX_STATUS........................... [PASS in 2.99s]
00:31:32  32 of 34 START test not_null_silver__transactions__INSERTED_TIMESTAMP........... [RUN]
00:31:33  17 of 34 PASS dbt_utils_unique_combination_of_columns_silver__transactions_tx_hash [PASS in 25.68s]
00:31:33  33 of 34 START test tx_gaps_silver__transactions_block_id__TX_HASH__tx_count.... [RUN]
00:31:34  31 of 34 PASS not_null_silver__transactions__INGESTED_AT........................ [PASS in 3.11s]
00:31:34  34 of 34 START test unique_silver__transactions_TX_HASH......................... [RUN]
00:31:35  32 of 34 PASS not_null_silver__transactions__INSERTED_TIMESTAMP................. [PASS in 3.31s]
00:33:25  34 of 34 PASS unique_silver__transactions_TX_HASH............................... [PASS in 110.73s]
00:34:15  33 of 34 WARN 283 tx_gaps_silver__transactions_block_id__TX_HASH__tx_count...... [WARN 283 in 162.42s]
00:35:29  26 of 34 PASS not_null_silver__transactions_TX.................................. [PASS in 249.73s]
00:35:29  
00:35:29  Finished running 34 tests, 1 hook in 286.61s.
00:35:29  
00:35:29  Completed with 1 warning:
00:35:29
00:35:29  Warning in test tx_gaps_silver__transactions_block_id__TX_HASH__tx_count (models/silver/silver__transactions.yml)
00:35:29    Got 283 results, configured to warn if != 0
00:35:29
00:35:29    compiled SQL at target/compiled/near/models/silver/silver__transactions.yml/tx_gaps_silver__transactions_block_id__TX_HASH__tx_count.sql
00:35:29
00:35:29  Done. PASS=33 WARN=1 ERROR=0 SKIP=0 TOTAL=34
```

**CORE__FACT_TRANSACTIONS**

`dbt_run`

```
root@f82ab8553319:/near/models/core# dbt run -s core__fact_transactions --full-refresh
00:37:28  Running with dbt=1.0.0
00:37:33  Found 38 models, 605 tests, 0 snapshots, 0 analyses, 628 macros, 1 operation, 1 seed file, 2 sources, 0 exposures, 0 metrics
00:37:33  
00:37:44  
00:37:44  Running 1 on-run-start hook
00:37:44  1 of 1 START hook: near.on-run-start.0.......................................... [RUN]
00:37:44  1 of 1 OK hook: near.on-run-start.0............................................. [OK in 0.00s]
00:37:44
00:37:44  Concurrency: 4 threads (target='dev')
00:37:44
00:37:44  1 of 1 START view model core.fact_transactions.................................. [RUN]
00:37:47  1 of 1 OK created view model core.fact_transactions............................. [SUCCESS 1 in 2.88s]
00:37:47  
00:37:47  Finished running 1 view model, 1 hook in 13.83s.
00:37:47  
00:37:47  Completed successfully
00:37:47
00:37:47  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

`dbt_test`

```
root@f82ab8553319:/near/models/core# dbt test --select core__fact_transactions
00:38:16  Running with dbt=1.0.0
00:38:22  Found 38 models, 605 tests, 0 snapshots, 0 analyses, 628 macros, 1 operation, 1 seed file, 2 sources, 0 exposures, 0 metrics
00:38:22  
00:38:30  
00:38:30  Running 1 on-run-start hook
00:38:30  1 of 1 START hook: near.on-run-start.0.......................................... [RUN]
00:38:30  1 of 1 OK hook: near.on-run-start.0............................................. [OK in 0.00s]
00:38:30
00:38:30  Concurrency: 4 threads (target='dev')
00:38:30
00:38:30  1 of 29 START test dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_ATTACHED_GAS__NUMBER__FLOAT [RUN]
00:38:30  2 of 29 START test dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_BLOCK_HASH__STRING__VARCHAR [RUN]
00:38:30  3 of 29 START test dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_BLOCK_ID__NUMBER__FLOAT [RUN]
00:38:30  4 of 29 START test dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_BLOCK_TIMESTAMP__TIMESTAMP_NTZ [RUN]
00:38:35  4 of 29 PASS dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_BLOCK_TIMESTAMP__TIMESTAMP_NTZ [PASS in 4.64s]
00:38:35  5 of 29 START test dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_GAS_USED__NUMBER__FLOAT [RUN]
00:38:35  2 of 29 PASS dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_BLOCK_HASH__STRING__VARCHAR [PASS in 4.90s]
00:38:35  6 of 29 START test dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_NONCE__NUMBER [RUN]
00:38:35  3 of 29 PASS dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_BLOCK_ID__NUMBER__FLOAT [PASS in 4.94s]
00:38:35  7 of 29 START test dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_SIGNATURE__STRING__VARCHAR [RUN]
00:38:35  1 of 29 PASS dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_ATTACHED_GAS__NUMBER__FLOAT [PASS in 5.11s]
00:38:35  8 of 29 START test dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_TRANSACTION_FEE__NUMBER__FLOAT [RUN]
00:38:40  8 of 29 PASS dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_TRANSACTION_FEE__NUMBER__FLOAT [PASS in 5.22s]
00:38:40  9 of 29 START test dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_TX_HASH__STRING__VARCHAR [RUN]
00:38:41  6 of 29 PASS dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_NONCE__NUMBER [PASS in 6.03s]
00:38:41  10 of 29 START test dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_TX_RECEIVER__STRING__VARCHAR [RUN]
00:38:41  5 of 29 PASS dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_GAS_USED__NUMBER__FLOAT [PASS in 6.70s]
00:38:41  11 of 29 START test dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_TX_SIGNER__STRING__VARCHAR [RUN]
00:38:42  7 of 29 PASS dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_SIGNATURE__STRING__VARCHAR [PASS in 6.69s]
00:38:42  12 of 29 START test dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_TX_STATUS__STRING__VARCHAR [RUN]
00:38:44  9 of 29 PASS dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_TX_HASH__STRING__VARCHAR [PASS in 3.33s]
00:38:44  13 of 29 START test dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_TX__OBJECT__VARIANT [RUN]
00:38:44  10 of 29 PASS dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_TX_RECEIVER__STRING__VARCHAR [PASS in 3.39s]
00:38:44  14 of 29 START test dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 [RUN]
00:38:45  11 of 29 PASS dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_TX_SIGNER__STRING__VARCHAR [PASS in 3.39s]
00:38:45  15 of 29 START test dbt_utils_unique_combination_of_columns_core__fact_transactions_tx_hash [RUN]
00:38:45  12 of 29 PASS dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_TX_STATUS__STRING__VARCHAR [PASS in 3.54s]
00:38:45  16 of 29 START test not_null_core__fact_transactions_ATTACHED_GAS............... [RUN]
00:38:48  13 of 29 PASS dbt_expectations_expect_column_values_to_be_in_type_list_core__fact_transactions_TX__OBJECT__VARIANT [PASS in 3.84s]
00:38:48  17 of 29 START test not_null_core__fact_transactions_BLOCK_HASH................. [RUN]
00:38:49  16 of 29 PASS not_null_core__fact_transactions_ATTACHED_GAS..................... [PASS in 3.32s]
00:38:49  18 of 29 START test not_null_core__fact_transactions_BLOCK_ID................... [RUN]
00:38:52  17 of 29 PASS not_null_core__fact_transactions_BLOCK_HASH....................... [PASS in 4.20s]
00:38:52  19 of 29 START test not_null_core__fact_transactions_BLOCK_TIMESTAMP............ [RUN]
00:38:52  18 of 29 PASS not_null_core__fact_transactions_BLOCK_ID......................... [PASS in 3.15s]
00:38:52  20 of 29 START test not_null_core__fact_transactions_GAS_USED................... [RUN]
00:38:52  14 of 29 PASS dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 [PASS in 8.09s]
00:38:52  21 of 29 START test not_null_core__fact_transactions_NONCE...................... [RUN]
00:38:55  20 of 29 PASS not_null_core__fact_transactions_GAS_USED......................... [PASS in 3.62s]
00:38:55  22 of 29 START test not_null_core__fact_transactions_SIGNATURE.................. [RUN]
00:38:56  21 of 29 PASS not_null_core__fact_transactions_NONCE............................ [PASS in 3.09s]
00:38:56  23 of 29 START test not_null_core__fact_transactions_TRANSACTION_FEE............ [RUN]
00:38:56  19 of 29 PASS not_null_core__fact_transactions_BLOCK_TIMESTAMP.................. [PASS in 3.94s]
00:38:56  24 of 29 START test not_null_core__fact_transactions_TX......................... [RUN]
00:38:59  22 of 29 PASS not_null_core__fact_transactions_SIGNATURE........................ [PASS in 3.47s]
00:38:59  25 of 29 START test not_null_core__fact_transactions_TX_HASH.................... [RUN]
00:38:59  23 of 29 PASS not_null_core__fact_transactions_TRANSACTION_FEE.................. [PASS in 3.62s]
00:38:59  26 of 29 START test not_null_core__fact_transactions_TX_RECEIVER................ [RUN]
00:39:02  26 of 29 PASS not_null_core__fact_transactions_TX_RECEIVER...................... [PASS in 2.96s]
00:39:02  27 of 29 START test not_null_core__fact_transactions_TX_SIGNER.................. [RUN]
00:39:03  25 of 29 PASS not_null_core__fact_transactions_TX_HASH.......................... [PASS in 4.10s]
00:39:03  28 of 29 START test not_null_core__fact_transactions_TX_STATUS.................. [RUN]
00:39:03  15 of 29 PASS dbt_utils_unique_combination_of_columns_core__fact_transactions_tx_hash [PASS in 18.28s]
00:39:03  29 of 29 START test unique_core__fact_transactions_TX_HASH...................... [RUN]
00:39:06  27 of 29 PASS not_null_core__fact_transactions_TX_SIGNER........................ [PASS in 3.63s]
00:39:07  28 of 29 PASS not_null_core__fact_transactions_TX_STATUS........................ [PASS in 3.91s]
00:41:05  29 of 29 PASS unique_core__fact_transactions_TX_HASH............................ [PASS in 121.94s]
00:42:37  24 of 29 PASS not_null_core__fact_transactions_TX............................... [PASS in 221.71s]
00:42:37
00:42:37  Finished running 29 tests, 1 hook in 255.53s.
00:42:38
00:42:38  Completed successfully
00:42:38
00:42:38  Done. PASS=29 WARN=0 ERROR=0 SKIP=0 TOTAL=29
```

- [x] Any comparison between `prod` and `dev` for any schema change
  - added `tx_status` to transactions table

# Checklist
- [x] Follow [dbt style guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md)
- [x] Tag the person(s) responsible for reviewing proposed changes: @forgxyz 
- [x] Notes to deployment, if a `full-refresh` is needed for any table
   - Need to full-refresh
- [x] Run `git merge main` to pull any changes from remote into your branch prior to merge.
