### PR TITLE
Staking pools

### DIFF
--- a/models/descriptions/staking_pool_address.md
+++ b/models/descriptions/staking_pool_address.md
@@ -1,0 +1,5 @@
+{% docs staking_pool_address %}
+
+The address of the staking pool.
+
+{% enddocs %}

--- a/models/descriptions/staking_pool_owner.md
+++ b/models/descriptions/staking_pool_owner.md
@@ -1,0 +1,5 @@
+{% docs staking_pool_owner %}
+
+The account of the staking pool owner.
+
+{% enddocs %}

--- a/models/descriptions/staking_pool_reward_fee_fraction.md
+++ b/models/descriptions/staking_pool_reward_fee_fraction.md
@@ -1,0 +1,5 @@
+{% docs staking_pool_reward_fee_fraction %}
+
+An object representing the fraction of the reward fee taken by the staking pool.
+
+{% enddocs %}

--- a/models/descriptions/staking_pool_tx_type.md
+++ b/models/descriptions/staking_pool_tx_type.md
@@ -1,0 +1,6 @@
+{% docs staking_pool_tx_type %}
+
+The type of transaction involving this staking pool.
+Either `"Create"` for staking pool creation or `"Update"` for `reward_fee_fraction` updates.
+
+{% enddocs %}

--- a/models/silver/silver__staking_pools.sql
+++ b/models/silver/silver__staking_pools.sql
@@ -1,0 +1,63 @@
+{{ 
+    config(
+        materialized = 'incremental',
+        cluster_by = ['block_timestamp'],
+        unique_key = 'tx_hash',
+        incremental_strategy = 'merge'
+    )
+}}
+with txs as (
+    select
+        tx_hash,
+        block_timestamp,
+        tx_signer,
+        tx_receiver,
+        tx,
+        _inserted_timestamp
+    from {{ ref('silver__transactions') }}
+    where {{ incremental_load_filter('_inserted_timestamp') }}
+),
+
+function_calls as (
+    select
+        tx_hash,
+        args,
+        method_name,
+        _inserted_timestamp
+    from {{ ref('silver__actions_events_function_call') }}
+    where method_name in ('create_staking_pool', 'update_reward_fee_fraction')
+      and {{ incremental_load_filter('_inserted_timestamp') }}
+),
+
+pool_txs as (
+    select
+        txs.tx_hash as tx_hash,
+        block_timestamp,
+        tx_signer,
+        tx_receiver,
+        args,
+        method_name,
+        tx,
+        txs._inserted_timestamp as _inserted_timestamp
+    from txs
+    inner join function_calls
+            on txs.tx_hash = function_calls.tx_hash
+    where tx:receipt[0]:outcome:status:SuccessValue is not null
+      or (method_name = 'create_staking_pool'
+          and tx:receipt[0]:outcome:status:SuccessReceiptId is not null
+          and tx:receipt[1]:outcome:status:SuccessValue is not null)
+),
+
+final as (
+    select 
+        pool_txs.tx_hash as tx_hash,
+        block_timestamp,
+        iff(method_name = 'create_staking_pool', args::variant::object:owner_id, tx_signer) as owner,
+        iff(method_name = 'create_staking_pool', tx:receipt[1]:outcome:executor_id::text, tx_receiver) as address,
+        args::variant::object:reward_fee_fraction as reward_fee_fraction,
+        iff(method_name = 'create_staking_pool', 'Create', 'Update') as tx_type,
+        _inserted_timestamp
+    from pool_txs
+)
+
+select * from final

--- a/models/silver/silver__staking_pools.yml
+++ b/models/silver/silver__staking_pools.yml
@@ -1,0 +1,60 @@
+version: 2
+
+models:
+  - name: silver__staking_pools
+    description: |-
+      This table extracts all staking pools registered with NEAR.
+
+    columns:
+      - name: tx_hash
+        description: "{{ doc('tx_hash')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+
+      - name: block_timestamp
+        description: "{{ doc('block_timestamp')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+
+      - name: owner
+        description: "{{ doc('staking_pool_owner')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+
+      - name: address
+        description: "{{ doc('staking_pool_address')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+
+      - name: reward_fee_fraction
+        description: "{{ doc('staking_pool_reward_fee_fraction')}}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - VARIANT
+                - OBJECT
+
+      - name: tx_type
+        description: "{{ doc('staking_pool_tx_type') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR


### PR DESCRIPTION
# Description

Create a table to track creation and updating of staking pool information. Addresses #96 .


# Tests
```
root@0da5076634e3:/near# dbt run -s silver__staking_pools
13:50:44  Running with dbt=1.0.0
13:50:45  Found 32 models, 604 tests, 0 snapshots, 0 analyses, 628 macros, 1 operation, 1 seed file, 2 sources, 0 exposures, 0 metrics
13:50:45
13:50:57
13:50:57  Running 1 on-run-start hook
13:50:57  1 of 1 START hook: near.on-run-start.0.......................................... [RUN]
13:50:57  1 of 1 OK hook: near.on-run-start.0............................................. [OK in 0.00s]
13:50:57
13:50:57  Concurrency: 4 threads (target='dev')
13:50:57
13:50:57  1 of 1 START incremental model silver.staking_pools............................. [RUN]
13:51:33  1 of 1 OK created incremental model silver.staking_pools........................ [SUCCESS 1 in 36.03s]
13:51:33
13:51:33  Finished running 1 incremental model, 1 hook in 48.20s.
13:51:33
13:51:33  Completed successfully
13:51:33
13:51:33  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
root@0da5076634e3:/near#
```
