### PR TITLE
Delegation actions

### DIFF
--- a/models/core/core__dim_staking_actions.sql
+++ b/models/core/core__dim_staking_actions.sql
@@ -1,0 +1,12 @@
+{{ config(
+    materialized = 'view',
+    secure = true
+) }}
+
+with staking_actions as (
+    select
+        *
+    from {{ ref('silver__staking_actions') }}
+)
+
+select * from staking_actions

--- a/models/core/core__dim_staking_actions.yml
+++ b/models/core/core__dim_staking_actions.yml
@@ -1,0 +1,73 @@
+version: 2
+
+models:
+  - name: core__dim_staking_actions
+    description: |-
+      This table records all the staking and delegation transactions occurring in NEAR. 
+
+      Be aware, however, not all transactions here necessarily actually contribute to securing the NEAR network.
+      Each epoch can have a different set of validators.
+
+    columns:
+      - name: tx_hash
+        description: "{{ doc('tx_hash') }}"
+        tests:
+          - unique
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+
+      - name: block_timestamp
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+
+      - name: pool_address
+        description: "{{ doc('staking_pool_address') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+
+      - name: tx_signer
+        description: "{{ doc('tx_signer') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+
+      - name: stake_amount
+        description: "{{ doc('staking_stake_amount') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+
+      - name: action
+        description: "{{ doc('staking_action') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+          - dbt_expectations.expect_column_values_to_be_in_set:
+              value_set: ['Stake', 'Unstake']
+
+      - name: _inserted_timestamp
+        description: "{{ doc('_inserted_timestamp') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ

--- a/models/descriptions/staking_action.md
+++ b/models/descriptions/staking_action.md
@@ -1,0 +1,5 @@
+{% docs staking_action %}
+
+The staking action performed in this transaction. Can be `"Stake"` or `"Unstake"`.
+
+{% enddocs %}

--- a/models/descriptions/staking_pool_address.md
+++ b/models/descriptions/staking_pool_address.md
@@ -1,5 +1,5 @@
 {% docs staking_pool_address %}
 
-The address of the staking pool.
+The pool address delegated into.
 
 {% enddocs %}

--- a/models/descriptions/staking_stake_amount.md
+++ b/models/descriptions/staking_stake_amount.md
@@ -1,0 +1,5 @@
+{% docs staking_stake_amount %}
+
+The amount staked or delegated toward securing the NEAR network.
+
+{% enddocs %}

--- a/models/silver/silver__staking_actions.sql
+++ b/models/silver/silver__staking_actions.sql
@@ -1,0 +1,161 @@
+{{ config(
+    materialized = 'incremental',
+    incremental = 'merge',
+    cluster_by = ['block_timestamp'],
+    unique_key = 'tx_hash'
+) }}
+
+with actions_events_function_call as (
+    select
+        tx_hash,
+        method_name,
+        _inserted_timestamp
+    from {{ ref('silver__actions_events_function_call') }}
+    where {{ incremental_load_filter('_inserted_timestamp') }}
+      and method_name in (
+        'deposit_and_stake',
+        'stake',
+        'unstake',
+        'unstake_all'
+      )
+),
+
+base_txs as (
+    select
+        *
+    from {{ ref('silver__transactions') }}
+    where {{ incremental_load_filter('_inserted_timestamp') }}
+),
+
+txs as (
+    select
+        *
+    from base_txs
+    where (tx_receiver like '%.pool.near' or tx_receiver like '%.poolv1.near')
+),
+
+pool_txs as (
+    select
+        txs.tx_hash as tx_hash,
+        block_timestamp,
+        tx_receiver,
+        tx_signer,
+        tx,
+        method_name,
+        txs._inserted_timestamp as _inserted_timestamp
+    from txs
+    inner join actions_events_function_call
+            on txs.tx_hash = actions_events_function_call.tx_hash
+),
+
+deposit_and_stake_txs as (
+    select
+        tx_hash,
+        block_timestamp,
+        tx_receiver as pool_address,
+        tx_signer,
+        coalesce(
+            regexp_substr(tx:receipt[0]:outcome:logs[1], 'staking (\\d+)', 1, 1, 'e')::number,
+            regexp_substr(tx:receipt[0]:outcome:logs[2], 'staking (\\d+)', 1, 1, 'e')::number,
+            regexp_substr(tx:receipt[0]:outcome:logs[3], 'staking (\\d+)', 1, 1, 'e')::number
+        ) as stake_amount,
+        'Stake' as action,
+        _inserted_timestamp
+    from pool_txs
+    where method_name = 'deposit_and_stake'
+      and tx:receipt[0]:outcome:status:SuccessValue is not null
+),
+
+stake_txs as (
+    select
+        tx_hash,
+        block_timestamp,
+        tx_receiver as pool_address,
+        tx_signer,
+        coalesce(
+            regexp_substr(tx:receipt[0]:outcome:logs[1], 'staking (\\d+)', 1, 1, 'e')::number,
+            regexp_substr(tx:receipt[0]:outcome:logs[2], 'staking (\\d+)', 1, 1, 'e')::number,
+            regexp_substr(tx:receipt[0]:outcome:logs[3], 'staking (\\d+)', 1, 1, 'e')::number
+        ) as stake_amount,
+        'Stake' as action,
+        _inserted_timestamp
+    from pool_txs
+    where method_name = 'stake'
+      and tx:receipt[0]:outcome:status:SuccessValue is not null
+),
+
+stake_all_txs as (
+    select
+        tx_hash,
+        block_timestamp,
+        tx_receiver as pool_address,
+        tx_signer,
+        coalesce(
+            regexp_substr(tx:receipt[0]:outcome:logs[0], 'staking (\\d+)', 1, 1, 'e')::number,
+            regexp_substr(tx:receipt[0]:outcome:logs[1], 'staking (\\d+)', 1, 1, 'e')::number,
+            regexp_substr(tx:receipt[0]:outcome:logs[2], 'staking (\\d+)', 1, 1, 'e')::number
+        ) as stake_amount,
+        'Stake' as action,
+        _inserted_timestamp
+    from pool_txs
+    where method_name = 'stake_all'
+      and tx:receipt[0]:outcome:status:SuccessValue is not null
+),
+
+unstake_txs as (
+    select
+        tx_hash,
+        block_timestamp,
+        tx_receiver as pool_address,
+        tx_signer,
+        coalesce(
+            regexp_substr(tx:receipt[0]:outcome:logs[0], 'unstaking (\\d+)', 1, 1, 'e')::number,
+            regexp_substr(tx:receipt[0]:outcome:logs[1], 'unstaking (\\d+)', 1, 1, 'e')::number,
+            regexp_substr(tx:receipt[0]:outcome:logs[2], 'unstaking (\\d+)', 1, 1, 'e')::number
+        ) as stake_amount,
+        'Unstake' as action,
+        _inserted_timestamp
+    from pool_txs
+    where method_name = 'unstake'
+      and tx:receipt[0]:outcome:status:SuccessValue is not null
+),
+
+unstake_all_txs as (
+    select
+        tx_hash,
+        block_timestamp,
+        tx_receiver as pool_address,
+        tx_signer,
+        coalesce(
+            regexp_substr(tx:receipt[0]:outcome:logs[0], 'unstaking (\\d+)', 1, 1, 'e')::number,
+            regexp_substr(tx:receipt[0]:outcome:logs[1], 'unstaking (\\d+)', 1, 1, 'e')::number,
+            regexp_substr(tx:receipt[0]:outcome:logs[2], 'unstaking (\\d+)', 1, 1, 'e')::number
+        ) as stake_amount,
+        'Unstake' as action,
+        _inserted_timestamp
+    from pool_txs
+    where method_name = 'unstake_all'
+      and tx:receipt[0]:outcome:status:SuccessValue is not null
+),
+
+final as (
+    select
+        *
+    from deposit_and_stake_txs
+    union
+    select
+        *
+    from stake_all_txs
+    union
+    select
+        *
+    from unstake_txs
+    union
+    select
+        *
+    from unstake_all_txs
+)
+
+select
+*
+from final

--- a/models/silver/silver__staking_actions.sql
+++ b/models/silver/silver__staking_actions.sql
@@ -54,11 +54,7 @@ deposit_and_stake_txs as (
         block_timestamp,
         tx_receiver as pool_address,
         tx_signer,
-        coalesce(
-            regexp_substr(tx:receipt[0]:outcome:logs[1], 'staking (\\d+)', 1, 1, 'e')::number,
-            regexp_substr(tx:receipt[0]:outcome:logs[2], 'staking (\\d+)', 1, 1, 'e')::number,
-            regexp_substr(tx:receipt[0]:outcome:logs[3], 'staking (\\d+)', 1, 1, 'e')::number
-        ) as stake_amount,
+        regexp_substr(array_to_string(tx:receipt[0]:outcome:logs, ','), 'staking (\\d+)', 1, 1, 'e')::number as stake_amount,
         'Stake' as action,
         _inserted_timestamp
     from pool_txs
@@ -72,11 +68,7 @@ stake_txs as (
         block_timestamp,
         tx_receiver as pool_address,
         tx_signer,
-        coalesce(
-            regexp_substr(tx:receipt[0]:outcome:logs[1], 'staking (\\d+)', 1, 1, 'e')::number,
-            regexp_substr(tx:receipt[0]:outcome:logs[2], 'staking (\\d+)', 1, 1, 'e')::number,
-            regexp_substr(tx:receipt[0]:outcome:logs[3], 'staking (\\d+)', 1, 1, 'e')::number
-        ) as stake_amount,
+        regexp_substr(array_to_string(tx:receipt[0]:outcome:logs, ','), 'staking (\\d+)', 1, 1, 'e')::number as stake_amount,
         'Stake' as action,
         _inserted_timestamp
     from pool_txs
@@ -90,11 +82,7 @@ stake_all_txs as (
         block_timestamp,
         tx_receiver as pool_address,
         tx_signer,
-        coalesce(
-            regexp_substr(tx:receipt[0]:outcome:logs[0], 'staking (\\d+)', 1, 1, 'e')::number,
-            regexp_substr(tx:receipt[0]:outcome:logs[1], 'staking (\\d+)', 1, 1, 'e')::number,
-            regexp_substr(tx:receipt[0]:outcome:logs[2], 'staking (\\d+)', 1, 1, 'e')::number
-        ) as stake_amount,
+        regexp_substr(array_to_string(tx:receipt[0]:outcome:logs, ','), 'staking (\\d+)', 1, 1, 'e')::number as stake_amount,
         'Stake' as action,
         _inserted_timestamp
     from pool_txs
@@ -108,11 +96,7 @@ unstake_txs as (
         block_timestamp,
         tx_receiver as pool_address,
         tx_signer,
-        coalesce(
-            regexp_substr(tx:receipt[0]:outcome:logs[0], 'unstaking (\\d+)', 1, 1, 'e')::number,
-            regexp_substr(tx:receipt[0]:outcome:logs[1], 'unstaking (\\d+)', 1, 1, 'e')::number,
-            regexp_substr(tx:receipt[0]:outcome:logs[2], 'unstaking (\\d+)', 1, 1, 'e')::number
-        ) as stake_amount,
+        regexp_substr(array_to_string(tx:receipt[0]:outcome:logs, ','), 'unstaking (\\d+)', 1, 1, 'e')::number as stake_amount,
         'Unstake' as action,
         _inserted_timestamp
     from pool_txs
@@ -126,11 +110,7 @@ unstake_all_txs as (
         block_timestamp,
         tx_receiver as pool_address,
         tx_signer,
-        coalesce(
-            regexp_substr(tx:receipt[0]:outcome:logs[0], 'unstaking (\\d+)', 1, 1, 'e')::number,
-            regexp_substr(tx:receipt[0]:outcome:logs[1], 'unstaking (\\d+)', 1, 1, 'e')::number,
-            regexp_substr(tx:receipt[0]:outcome:logs[2], 'unstaking (\\d+)', 1, 1, 'e')::number
-        ) as stake_amount,
+        regexp_substr(array_to_string(tx:receipt[0]:outcome:logs, ','), 'unstaking (\\d+)', 1, 1, 'e')::number as stake_amount,
         'Unstake' as action,
         _inserted_timestamp
     from pool_txs

--- a/models/silver/silver__staking_actions.yml
+++ b/models/silver/silver__staking_actions.yml
@@ -4,6 +4,9 @@ models:
   - name: silver__staking_actions
     description: |-
       This table records all the staking and delegation transactions occurring in NEAR. 
+
+      Be aware, however, not all transactions here necessarily actually contribute to securing the NEAR network.
+      Each epoch can have a different set of validators.
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:

--- a/models/silver/silver__staking_actions.yml
+++ b/models/silver/silver__staking_actions.yml
@@ -1,0 +1,72 @@
+version: 2
+
+models:
+  - name: silver__staking_actions
+    description: |-
+      This table records all the staking and delegation transactions occurring in NEAR. 
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+
+    columns:
+      - name: tx_hash
+        description: "{{ doc('tx_hash') }}"
+        tests:
+          - unique
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+
+      - name: block_timestamp
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+
+      - name: pool_address
+        description: "{{ doc('staking_pool_address') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+
+      - name: tx_signer
+        description: "{{ doc('tx_signer') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+
+      - name: stake_amount
+        description: "{{ doc('staking_stake_amount') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+
+      - name: action
+        description: "{{ doc('staking_action') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+
+      - name: _inserted_timestamp
+        description: "{{ doc('_inserted_timestamp') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ


### PR DESCRIPTION
# Description

Creates a new table tracking staking actions. Addresses #64.


# Tests

```
root@ffafe8db9627:/near# dbt run -s silver__staking_actions
13:09:01  Running with dbt=1.0.0
13:09:02  Found 32 models, 608 tests, 0 snapshots, 0 analyses, 628 macros, 1 operation, 1 seed file, 2 sources, 0 exposures, 0 metrics
13:09:02
13:09:15
13:09:15  Running 1 on-run-start hook
13:09:15  1 of 1 START hook: near.on-run-start.0.......................................... [RUN]
13:09:15  1 of 1 OK hook: near.on-run-start.0............................................. [OK in 0.00s]
13:09:15
13:09:15  Concurrency: 4 threads (target='dev')
13:09:15
13:09:15  1 of 1 START incremental model silver.staking_actions........................... [RUN]
13:11:06  1 of 1 OK created incremental model silver.staking_actions...................... [SUCCESS 1 in 111.01s]
13:11:06
13:11:06  Finished running 1 incremental model, 1 hook in 124.09s.
13:11:06
13:11:06  Completed successfully
13:11:06
13:11:06  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```
