### PR TITLE
custom_name_macros: fix namespace conflict on test

### DIFF
--- a/macros/custom_naming_macros.sql
+++ b/macros/custom_naming_macros.sql
@@ -13,5 +13,9 @@
     ) -%}
     {% set node_name = node.name %}
     {% set split_name = node_name.split('__') %}
+    {%- if node.resource_type != 'test' -%}
     {{ split_name [1] | trim }}
+    {%- else -%}
+    {{ node_name }}
+    {%- endif -%}
 {%- endmacro %}


### PR DESCRIPTION
# Description

Fixes namespace conflict that occurs on `dbt test --store-failures`.

The current custom naming scheme can resolve to a conflict since we split on '__'. By adding an extra condition to see whether we're executing a test, we can let dbt resolve to different alias names.
