### PR TITLE
Dex swaps bug fix

### DIFF
--- a/models/silver/silver__dex_swaps.sql
+++ b/models/silver/silver__dex_swaps.sql
@@ -5,41 +5,63 @@
     cluster_by = ["block_timestamp::DATE", "_inserted_timestamp::DATE"],
 ) }}
 
-WITH actions AS (
+WITH base_swaps as (
+    select
+        block_id,
+        block_timestamp,
+        tx_hash,
+        action_id,
+        parse_json(args):actions as actions,
+        _inserted_timestamp
+    from {{ ref('silver__actions_events_function_call') }}
+    where method_name = 'swap'
+      and args like '%actions%'
+      and {{ incremental_load_filter('_inserted_timestamp') }}
+),
+
+agg_swaps as (
+    select
+        tx_hash,
+        any_value(block_id) as block_id,
+        any_value(block_timestamp) as block_timestamp,
+        array_agg(action.value) within group (order by action_id, action.index) as action_list,
+        any_value(_inserted_timestamp) as _inserted_timestamp
+    from
+        base_swaps,
+        lateral flatten(input => actions) action
+    group by 1
+),
+
+actions AS (
 
     SELECT
         block_id,
         block_timestamp,
         tx_hash,
-        args,
-        method_name,
         NULLIF(
-            j.value :pool_id,
+            action.value :pool_id,
             NULL
         ) AS pool_id,
         NULLIF(
-            j.value :token_in,
+            action.value :token_in,
             NULL
         ) :: text AS token_in,
         NULLIF(
-            j.value :token_out,
+            action.value :token_out,
             NULL
         ) :: text AS token_out,
-        j.index AS swap_index,
+        action.index AS swap_index,
         _inserted_timestamp
     FROM
-        {{ ref("silver__actions_events_function_call") }},
-        LATERAL FLATTEN(input => PARSE_JSON(args) :actions) j
-    WHERE
-        method_name = 'swap'
-        AND args LIKE '%actions%'
-        AND NOT RLIKE(
-            pool_id,
-            '.*[a-z].*',
-            'i'
-        )
-        AND {{ incremental_load_filter("_inserted_timestamp") }}
+        agg_swaps,
+        LATERAL FLATTEN(input => action_list) action
+    where not rlike(
+        pool_id,
+        '.*[a-z].*',
+        'i'
+    )
 ),
+
 receipts AS (
     SELECT
         block_id,
@@ -55,8 +77,29 @@ receipts AS (
     FROM
         {{ ref("silver__receipts") }}
     WHERE
-        {{ incremental_load_filter("_inserted_timestamp") }}
+        tx_hash in (select tx_hash from actions)
 ),
+
+flat_receipts as (
+    select
+        tx_hash,
+        l.value,
+        l.index,
+        success_or_fail
+    from receipts,
+    lateral flatten(input => logs) l
+),
+
+swap_logs as (
+    select
+        tx_hash,
+        row_number() over (partition by tx_hash order by index asc) - 1 as swap_index,
+        value,
+        success_or_fail
+    from flat_receipts
+    where value like 'Swapped%'
+),
+
 transactions AS (
     SELECT
         block_id,
@@ -66,76 +109,73 @@ transactions AS (
         tx_receiver
     FROM
         {{ ref("silver__transactions") }}
-    WHERE
-        {{ incremental_load_filter("_inserted_timestamp") }}
+    where tx_hash in (select tx_hash from actions)
 ),
-token_in_labels AS (
+token_labels AS (
     SELECT
         *
     FROM
         {{ ref("silver__token_labels") }}
 ),
-token_out_labels AS (
-    SELECT
-        *
-    FROM
-        token_in_labels
-),
 final_table AS (
     SELECT
-        DISTINCT actions.swap_index,
+        swap_logs.swap_index,
         actions._inserted_timestamp,
         actions.block_id,
         actions.block_timestamp,
-        actions.tx_hash,
+        swap_logs.tx_hash,
         CONCAT(
-            actions.tx_hash,
+            swap_logs.tx_hash,
             '-',
-            actions.swap_index
+            swap_logs.swap_index
         ) AS swap_id,
-        logs,
-        logs [swap_index] AS log_data,
+        swap_logs.value AS log_data,
         transactions.tx_signer AS trader,
         transactions.tx_receiver AS platform,
         LAST_VALUE(
-            receipts.success_or_fail
+            swap_logs.success_or_fail
         ) over (
-            PARTITION BY receipts.tx_hash
+            PARTITION BY swap_logs.tx_hash
             ORDER BY
-                receipts.success_or_fail DESC
+                swap_logs.success_or_fail DESC
         ) AS txn_status,
         actions.pool_id :: INT AS pool_id,
         actions.token_in,
         actions.token_out
     FROM
         actions
-        JOIN receipts
-        ON actions.tx_hash = receipts.tx_hash
+        inner join swap_logs
+                on (swap_logs.tx_hash = actions.tx_hash
+                and swap_logs.swap_index = actions.swap_index)
         JOIN transactions
         ON actions.tx_hash = transactions.tx_hash
+),
+final as (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_hash,
+        swap_id,
+        platform,
+        trader,
+        pool_id,
+        token_in,
+        token_labels_in.symbol AS token_in_symbol,
+        regexp_substr(log_data, 'Swapped (\\d+)', 1, 1, 'e')::number / pow(10, token_labels_in.decimals) as amount_in,
+        token_out,
+        token_labels_out.symbol AS token_out_symbol,
+        regexp_substr(log_data, 'Swapped \\d+ .+ for (\\d+)', 1, 1, 'e')::number / pow(10, token_labels_out.decimals) as amount_out,
+        swap_index,
+        _inserted_timestamp
+    FROM
+        final_table
+        LEFT JOIN token_labels AS token_labels_in
+        ON final_table.token_in = token_labels_in.token_contract
+        LEFT JOIN token_labels AS token_labels_out
+        ON final_table.token_out = token_labels_out.token_contract
+    WHERE
+        txn_status = 'Success'
+        AND log_data IS NOT NULL
 )
-SELECT
-    block_id,
-    block_timestamp,
-    tx_hash,
-    swap_id,
-    platform,
-    trader,
-    pool_id,
-    token_in,
-    token_labels_in.symbol AS token_in_symbol,
-    regexp_substr(log_data, 'Swapped (\\d+)', 1, 1, 'e')::number / pow(10, token_labels_in.decimals) as amount_in,
-    token_out,
-    token_labels_out.symbol AS token_out_symbol,
-    regexp_substr(log_data, 'Swapped \\d+ .+ for (\\d+)', 1, 1, 'e')::number / pow(10, token_labels_out.decimals) as amount_out,
-    swap_index,
-    _inserted_timestamp
-FROM
-    final_table
-    LEFT JOIN token_labels AS token_labels_in
-    ON final_table.token_in = token_labels_in.token_contract
-    LEFT JOIN token_labels AS token_labels_out
-    ON final_table.token_out = token_labels_out.token_contract
-WHERE
-    txn_status = 'Success'
-    AND log_data IS NOT NULL
+
+select * from final

--- a/models/silver/silver__dex_swaps.sql
+++ b/models/silver/silver__dex_swaps.sql
@@ -113,9 +113,6 @@ final_table AS (
         ON actions.tx_hash = receipts.tx_hash
         JOIN transactions
         ON actions.tx_hash = transactions.tx_hash
-    ORDER BY
-        tx_hash,
-        swap_index
 )
 SELECT
     block_id,
@@ -148,5 +145,3 @@ FROM
 WHERE
     txn_status = 'Success'
     AND log_data IS NOT NULL
-ORDER BY
-    swap_id DESC

--- a/models/silver/silver__dex_swaps.sql
+++ b/models/silver/silver__dex_swaps.sql
@@ -161,10 +161,10 @@ final as (
         pool_id,
         token_in,
         token_labels_in.symbol AS token_in_symbol,
-        regexp_substr(log_data, 'Swapped (\\d+)', 1, 1, 'e')::number / pow(10, token_labels_in.decimals) as amount_in,
+        regexp_substr(log_data, 'Swapped (\\d+)', 1, 1, 'e')::number / pow(10, ifnull(token_labels_in.decimals, 0)) as amount_in,
         token_out,
         token_labels_out.symbol AS token_out_symbol,
-        regexp_substr(log_data, 'Swapped \\d+ .+ for (\\d+)', 1, 1, 'e')::number / pow(10, token_labels_out.decimals) as amount_out,
+        regexp_substr(log_data, 'Swapped \\d+ .+ for (\\d+)', 1, 1, 'e')::number / pow(10, ifnull(token_labels_out.decimals, 0)) as amount_out,
         swap_index,
         _inserted_timestamp
     FROM

--- a/models/silver/silver__dex_swaps.sql
+++ b/models/silver/silver__dex_swaps.sql
@@ -124,16 +124,10 @@ SELECT
     pool_id,
     token_in,
     token_labels_in.symbol AS token_in_symbol,
-    TRIM(REGEXP_SUBSTR(log_data, '\\W[\\d]{1,}\\W', 1, 1)) :: bigint / pow(
-        10,
-        token_labels_in.decimals
-    ) :: numeric AS amount_in,
+    regexp_substr(log_data, 'Swapped (\\d+)', 1, 1, 'e')::number / pow(10, token_labels_in.decimals) as amount_in,
     token_out,
     token_labels_out.symbol AS token_out_symbol,
-    TRIM(REGEXP_SUBSTR(log_data, '\\W[\\d]{1,}\\W', 1, 2)) :: bigint / pow(
-        10,
-        token_labels_out.decimals
-    ) :: numeric AS amount_out,
+    regexp_substr(log_data, 'Swapped \\d+ .+ for (\\d+)', 1, 1, 'e')::number / pow(10, token_labels_out.decimals) as amount_out,
     swap_index,
     _inserted_timestamp
 FROM

--- a/models/silver/silver__dex_swaps.yml
+++ b/models/silver/silver__dex_swaps.yml
@@ -8,6 +8,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - swap_id
+      - dex_swaps_token_amounts
 
     columns:
       - name: BLOCK_ID

--- a/models/silver/silver__dex_swaps.yml
+++ b/models/silver/silver__dex_swaps.yml
@@ -8,7 +8,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - swap_id
-      - dex_swaps_token_amounts
 
     columns:
       - name: BLOCK_ID

--- a/tests/dex_swaps_token_amounts.sql
+++ b/tests/dex_swaps_token_amounts.sql
@@ -46,7 +46,15 @@ expected_adjusted as (
 
 test as (
     select
-        *
+        expected_adjusted.swap_id,
+        expected_adjusted.amount_in as expected_amount_in,
+        expected_adjusted.token_in as expected_token_in,
+        swaps.amount_in as actual_amount_in,
+        swaps.token_in as actual_token_in,
+        expected_adjusted.amount_out as expected_amount_out,
+        expected_adjusted.token_out as expected_token_out,
+        swaps.amount_out as actual_amount_out,
+        swaps.token_out as actual_token_out
     from expected_adjusted
     inner join swaps on expected_adjusted.swap_id = swaps.swap_id
     where expected_adjusted.amount_in != swaps.amount_in

--- a/tests/dex_swaps_token_amounts.sql
+++ b/tests/dex_swaps_token_amounts.sql
@@ -1,0 +1,58 @@
+with swaps as (
+    select
+        swap_id,
+        tx_hash,
+        token_in,
+        amount_in,
+        token_out,
+        amount_out
+    from {{ ref('silver__dex_swaps') }}
+),
+
+swap_logs as (
+    select
+        tx_hash,
+        tx:receipt[0]:outcome:logs as logs
+    from {{ ref('silver__transactions') }}
+    where tx_hash in (select tx_hash from swaps)
+),
+
+expected as (
+    select
+        concat(tx_hash, '-', row_number() over (partition by tx_hash order by index asc) - 1) as swap_id,
+        regexp_substr(value, 'Swapped (\\d+)', 1, 1, 'e')::number as amount_in,
+        regexp_substr(value, 'Swapped \\d+ (.+) for ', 1, 1, 'e') as token_in,
+        regexp_substr(value, 'Swapped \\d+ .+ for (\\d+)', 1, 1, 'e')::number as amount_out,
+        regexp_substr(value, 'Swapped \\d+ .+ for \\d+ ([^,]+)', 1, 1, 'e') as token_out
+    from swap_logs,
+    lateral flatten(input => logs)
+    where amount_in is not null
+       or token_in is not null
+       or amount_out is not null
+       or amount_in is not null
+),
+
+expected_adjusted as (
+    select
+        swap_id,
+        token_in,
+        amount_in / pow(10, labels_in.decimals) as amount_in,
+        token_out,
+        amount_out / pow(10, labels_out.decimals) as amount_out 
+    from expected
+    inner join token_labels labels_in on expected.token_in = labels_in.token_contract
+    inner join token_labels labels_out on expected.token_out = labels_out.token_contract
+),
+
+test as (
+    select
+        *
+    from expected_adjusted
+    inner join swaps on expected_adjusted.swap_id = swaps.swap_id
+    where expected_adjusted.amount_in != swaps.amount_in
+       or expected_adjusted.token_in != swaps.token_in
+       or expected_adjusted.amount_out != swaps.amount_out
+       or expected_adjusted.token_out != swaps.token_out
+)
+
+select * from test


### PR DESCRIPTION
# Description

Fixes #116. Also adds tests for token amounts.


# Tests

```
root@80dfc3d72caa:/near# dbt run -s silver__dex_swaps --full-refresh
08:56:10  Running with dbt=1.2.0
08:56:11  Found 38 models, 699 tests, 0 snapshots, 0 analyses, 682 macros, 1 operation, 1 seed file, 3 sources, 0 exposures, 0 metrics
08:56:11
08:56:21
08:56:21  Running 1 on-run-start hook
08:56:21  1 of 1 START hook: near.on-run-start.0 ......................................... [RUN]
08:56:21  1 of 1 OK hook: near.on-run-start.0 ............................................ [OK in 0.00s]
08:56:21
08:56:21  Concurrency: 4 threads (target='dev')
08:56:21
08:56:21  1 of 1 START incremental model silver.dex_swaps ................................ [RUN]
08:58:35  1 of 1 OK created incremental model silver.dex_swaps ........................... [SUCCESS 1 in 133.98s]
08:58:35
08:58:35  Finished running 1 incremental model, 1 hook in 0 hours 2 minutes and 24.09 seconds (144.09s).
08:58:35
08:58:35  Completed successfully
08:58:35
08:58:35  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

@forgxyz Will require a full-refresh to fix existing bug when merged.