### PR TITLE
Bugfix/missing dex swaps

### DIFF
--- a/tests/dex_swaps_come_from_actions_events_function_call.sql
+++ b/tests/dex_swaps_come_from_actions_events_function_call.sql
@@ -1,0 +1,45 @@
+with actual as (
+    select tx_hash from {{ ref('silver__dex_swaps') }}
+),
+
+success_txs as (
+    select tx_hash
+    from {{ ref('silver__transactions') }}
+    where tx_status = 'Success'
+),
+
+expected as (
+    select
+        tx_hash,
+        iff(method_name = 'ft_transfer_call',
+            try_parse_json(try_parse_json(args):msg),
+            try_parse_json(args)
+        ):actions as actions
+    from {{ ref('silver__actions_events_function_call') }}
+    where method_name in ('ft_transfer_call', 'swap')
+      and tx_hash in (select tx_hash from success_txs)
+      and actions is not null
+      and array_size(actions) > 0
+),
+
+in_both as (
+    select
+        tx_hash
+    from expected
+    where tx_hash in (select tx_hash from actual)
+),
+
+both as (
+    select
+        tx_hash
+    from expected
+    union
+    select
+        tx_hash
+    from actual
+)
+
+select
+    tx_hash
+from both
+where tx_hash not in (select tx_hash from in_both)

--- a/tests/dex_swaps_token_amounts.sql
+++ b/tests/dex_swaps_token_amounts.sql
@@ -12,7 +12,11 @@ with swaps as (
 swap_logs as (
     select
         tx_hash,
-        tx:receipt[0]:outcome:logs as logs
+        tx:actions[0]:FunctionCall:method_name as method_name,
+        iff(method_name = 'ft_transfer_call',
+            tx:receipt[1]:outcome:logs,
+            tx:receipt[0]:outcome:logs
+        ) as logs
     from {{ ref('silver__transactions') }}
     where tx_hash in (select tx_hash from swaps)
 ),


### PR DESCRIPTION
# Description

Fixes #127 

Swaps using fungible tokens use `ft_transfer_call` instead of the immediate `swap` method. This PR includes swaps using `ft_transfer_call`.

Since we want to include the missed swaps, this will require a full-refresh. (@forgxyz)

The tests come up with a warning. This is related to #110. Some transactions are marked as failures when they are actually successful according to the explorer. These rows come up here, since `silver.dex_swaps` has its own method of determining tx success, compared to my test which relies on `silver.transactions`.

# Tests

```
16:54:02  Found 38 models, 700 tests, 0 snapshots, 0 analyses, 682 macros, 1 operation, 1 seed file, 3 sources, 0 exposures, 0 metrics
16:54:03
16:54:11
16:54:11  Running 1 on-run-start hook
16:54:11  1 of 1 START hook: near.on-run-start.0 ......................................... [RUN]
16:54:11  1 of 1 OK hook: near.on-run-start.0 ............................................ [OK in 0.00s]
16:54:11
16:54:11  Concurrency: 4 threads (target='dev')
16:54:11
16:54:11  1 of 26 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_AMOUNT_IN__NUMBER__FLOAT__DOUBLE  [RUN]
16:54:11  2 of 26 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_AMOUNT_OUT__NUMBER__FLOAT__DOUBLE  [RUN]
16:54:11  3 of 26 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_BLOCK_ID__NUMBER__FLOAT  [RUN]
16:54:11  4 of 26 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_BLOCK_TIMESTAMP__TIMESTAMP_NTZ  [RUN]
16:54:15  3 of 26 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_BLOCK_ID__NUMBER__FLOAT  [PASS in 4.01s]
16:54:15  5 of 26 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_PLATFORM__STRING__VARCHAR  [RUN]
16:54:15  1 of 26 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_AMOUNT_IN__NUMBER__FLOAT__DOUBLE  [PASS in 4.04s]
16:54:15  6 of 26 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_POOL_ID__NUMBER__FLOAT  [RUN]
16:54:15  4 of 26 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_BLOCK_TIMESTAMP__TIMESTAMP_NTZ  [PASS in 4.52s]
16:54:15  2 of 26 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_AMOUNT_OUT__NUMBER__FLOAT__DOUBLE  [PASS in 4.52s]
16:54:15  7 of 26 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_SWAP_ID__STRING__VARCHAR  [RUN]
16:54:15  8 of 26 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_SWAP_INDEX__NUMBER  [RUN]
16:54:18  5 of 26 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_PLATFORM__STRING__VARCHAR  [PASS in 3.38s]
16:54:18  9 of 26 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_TOKEN_IN__STRING__VARCHAR  [RUN]
16:54:18  6 of 26 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_POOL_ID__NUMBER__FLOAT  [PASS in 3.49s]
16:54:18  10 of 26 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_TOKEN_OUT__STRING__VARCHAR  [RUN]
16:54:19  7 of 26 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_SWAP_ID__STRING__VARCHAR  [PASS in 3.73s]
16:54:19  11 of 26 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_TRADER__STRING__VARCHAR  [RUN]
16:54:19  8 of 26 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_SWAP_INDEX__NUMBER  [PASS in 3.75s]
16:54:19  12 of 26 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_TX_HASH__STRING__VARCHAR  [RUN]
16:54:22  10 of 26 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_TOKEN_OUT__STRING__VARCHAR  [PASS in 3.54s]
16:54:22  13 of 26 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps__INSERTED_TIMESTAMP__TIMESTAMP_NTZ  [RUN]
16:54:22  9 of 26 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_TOKEN_IN__STRING__VARCHAR  [PASS in 3.70s]
16:54:22  14 of 26 START test dbt_utils_unique_combination_of_columns_silver__dex_swaps_swap_id  [RUN]
16:54:23  12 of 26 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_TX_HASH__STRING__VARCHAR  [PASS in 3.59s]
16:54:23  15 of 26 START test dex_swaps_come_from_actions_events_function_call ........... [RUN]
16:54:23  11 of 26 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps_TRADER__STRING__VARCHAR  [PASS in 4.12s]
16:54:23  16 of 26 START test dex_swaps_token_amounts .................................... [RUN]
16:54:26  13 of 26 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__dex_swaps__INSERTED_TIMESTAMP__TIMESTAMP_NTZ  [PASS in 3.94s]
16:54:26  17 of 26 START test not_null_silver__dex_swaps_AMOUNT_IN ....................... [RUN]
16:54:26  16 of 26 PASS dex_swaps_token_amounts .......................................... [PASS in 3.35s]
16:54:26  18 of 26 START test not_null_silver__dex_swaps_BLOCK_ID ........................ [RUN]
16:54:27  14 of 26 PASS dbt_utils_unique_combination_of_columns_silver__dex_swaps_swap_id  [PASS in 5.06s]
16:54:27  19 of 26 START test not_null_silver__dex_swaps_BLOCK_TIMESTAMP ................. [RUN]
16:54:29  17 of 26 PASS not_null_silver__dex_swaps_AMOUNT_IN ............................. [PASS in 2.90s]
16:54:29  20 of 26 START test not_null_silver__dex_swaps_PLATFORM ........................ [RUN]
16:54:30  19 of 26 PASS not_null_silver__dex_swaps_BLOCK_TIMESTAMP ....................... [PASS in 3.34s]
16:54:30  21 of 26 START test not_null_silver__dex_swaps_SWAP_ID ......................... [RUN]
16:54:30  18 of 26 PASS not_null_silver__dex_swaps_BLOCK_ID .............................. [PASS in 3.80s]
16:54:30  22 of 26 START test not_null_silver__dex_swaps_SWAP_INDEX ...................... [RUN]
16:54:32  20 of 26 PASS not_null_silver__dex_swaps_PLATFORM .............................. [PASS in 2.90s]
16:54:32  23 of 26 START test not_null_silver__dex_swaps_TRADER .......................... [RUN]
16:54:33  21 of 26 PASS not_null_silver__dex_swaps_SWAP_ID ............................... [PASS in 3.17s]
16:54:33  24 of 26 START test not_null_silver__dex_swaps_TX_HASH ......................... [RUN]
16:54:34  22 of 26 PASS not_null_silver__dex_swaps_SWAP_INDEX ............................ [PASS in 3.36s]
16:54:34  25 of 26 START test not_null_silver__dex_swaps__INSERTED_TIMESTAMP ............. [RUN]
16:54:34  23 of 26 PASS not_null_silver__dex_swaps_TRADER ................................ [PASS in 2.85s]
16:54:34  26 of 26 START test unique_silver__dex_swaps_SWAP_ID ........................... [RUN]
16:54:37  24 of 26 PASS not_null_silver__dex_swaps_TX_HASH ............................... [PASS in 3.43s]
16:54:37  25 of 26 PASS not_null_silver__dex_swaps__INSERTED_TIMESTAMP ................... [PASS in 3.39s]
16:54:38  26 of 26 PASS unique_silver__dex_swaps_SWAP_ID ................................. [PASS in 3.63s]
16:55:36  15 of 26 WARN 653 dex_swaps_come_from_actions_events_function_call ............. [WARN 653 in 73.42s]
16:55:36
16:55:36  Finished running 26 tests, 1 hook in 0 hours 1 minutes and 33.49 seconds (93.49s).
16:55:36
16:55:36  Completed with 1 warning:
16:55:36
16:55:36  Warning in test dex_swaps_come_from_actions_events_function_call (tests/dex_swaps_come_from_actions_events_function_call.sql)
16:55:36    Got 653 results, configured to warn if != 0
16:55:36
16:55:36    compiled SQL at target/compiled/near/tests/dex_swaps_come_from_actions_events_function_call.sql
16:55:36
16:55:36  Done. PASS=25 WARN=1 ERROR=0 SKIP=0 TOTAL=26
```
